### PR TITLE
禁用XML外部实体注入

### DIFF
--- a/src/main/java/me/hao0/common/xml/XmlReaders.java
+++ b/src/main/java/me/hao0/common/xml/XmlReaders.java
@@ -24,7 +24,10 @@ public class XmlReaders {
 
     static {
         try {
-            builder =  DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+            // 禁用XML 外部实体注入
+            documentBuilderFactory.setExpandEntityReferences(false);
+            builder =  documentBuilderFactory.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
             throw new XmlException("init xml failed");
         }


### PR DESCRIPTION
XML 外部实体注入漏洞(XML External Entity Injection，简称 XXE)，是一种容易被忽视，但危害巨大的漏洞。它可以利用 XML 外部实体加载注入，执行不可预控的代码，可导致读取任意文件、执行系统命令、探测内网端口、攻击内网网站等危害。